### PR TITLE
Command line API to write results to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.log
 *.out
 *.gsd
+*.csv

--- a/README.md
+++ b/README.md
@@ -14,15 +14,13 @@ simulation performance between different versions, build configurations, or syst
   * `mpirun -n 2 python3 -m hoomd_benchmarks.md_pair_wca --device GPU -N 1000000 -v`
   * `mpirun -n 4 python3 -m hoomd_benchmarks.hpmc_sphere --device CPU -N 4000 --repeat 10`
 3. Run the full benchmarks suite:
+  * `python3 -m hoomd_benchmarks --device CPU`
   * `mpirun -n 8 python3 -m hoomd_benchmarks --device CPU`
-4. See the available command line options:
-  * `python3 -m hoomd_benchmarks.md_pair_lj --help`
 
 The first execution will take some time as the benchmark generates the requested input
-configuration. Subsequent runs with the same paramters will start up faster as the system
-configuration will be read from `initial_configuration_cache/` if it exists. Activate the verbose
-`-v` command line option to see status messages during the initial configuration generation and the
-benchmark execution.
+configuration. Subsequent runs with the same paramters will read input configurations from
+`initial_configuration_cache/` if it exists. Activate the verbose `-v` command line option to see
+status messages during the initial configuration generation and the benchmark execution.
 
 ## Scripting
 
@@ -31,9 +29,37 @@ Use this in conjunction with scripts to execute a number of benchmarks and compa
 Python scripts can import the `hoomd_benchmarks` module and call the `Benchmark` classes directly.
 See their docstrings for details.
 
+## Common options
+
+The following command line options are available for both the full test suite and individual
+tests:
+
+* `--device`: Set what device to execute the benchmark on. Either `CPU` or `GPU`.
+* `-N`: Number of particles.
+* `--rho`: Number density.
+* `--dimensions`: Number of dimensions. Either `2` or `3`.
+* `--warmup_steps`: Number of timesteps to run before timing.
+* `--benchmark_steps`: Number of timesteps to run in the benchmark.
+* `--repeat`: Number of times to repeat the run.
+* `--verbose`: Enable verbose output.
+
+When using the Python API, pass these options to the benchmark's constructor.
+
+## The benchmark suite
+
+Run the full suite with `python3 -m hoomd_benchmarks <options>`.
+
+The full suite accepts the following command line options in addition to the common options:
+
+* `--benchmarks`: Select the benchmarks to run by class name using `fnmatch` syntax.
+* `--output`: Add row of benchmark results to or create the output CSV file.
+* `--name`: Name identifying this benchmark run.
+
 ## Benchmarks
 
-Run any of these benchmarks individually with: `python3 -m hoomd_benchmarks.<benchmark_name>`:
+Run any benchmark individually with `python3 -m hoomd_benchmarks.<benchmark_name> <options>`.
+Some benchmarks have additional command line options, find these with
+`python3 -m hoomd_benchmarks.<benchmark_name> --help`.
 
 ### Simulation benchmarks
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This repository contains performance benchmarks for [HOOMD-blue][hoomd]. Use the
 your HOOMD-blue installation, check the performance of simulations on your hardware, or compare
 simulation performance between different versions, build configurations, or systems.
 
+## Requirements
+
+* HOOMD-blue v3.0-beta
+* numpy
+* pandas
+
 ## Usage
 
 1. Clone this repository:
@@ -52,7 +58,7 @@ Run the full suite with `python3 -m hoomd_benchmarks <options>`.
 The full suite accepts the following command line options in addition to the common options:
 
 * `--benchmarks`: Select the benchmarks to run by class name using `fnmatch` syntax.
-* `--output`: Add row of benchmark results to or create the output CSV file.
+* `--output`: Add column of benchmark results to or create the output CSV file.
 * `--name`: Name identifying this benchmark run.
 
 ## Benchmarks

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -68,7 +68,7 @@ if args.output is not None and benchmark_args['device'].communicator.rank == 0:
     df = pandas.DataFrame.from_dict(performance,
                                     orient='index',
                                     columns=[args.name])
-    # append to the existing data file if the file exists
+
     if os.path.isfile(args.output):
         df_old = pandas.read_csv(args.output, index_col=0)
         df = df_old.join(df)

--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -171,7 +171,7 @@ class Benchmark:
         parser.add_argument('--warmup_steps',
                             type=int,
                             default=DEFAULT_WARMUP_STEPS,
-                            help='Number of timesteps to run to warm up stage.')
+                            help='Number of timesteps to run before timing.')
         parser.add_argument('--benchmark_steps',
                             type=int,
                             default=DEFAULT_BENCHMARK_STEPS,


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add the `output` and `name`, and `benchmarks` command line arguments to the main entry point.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
* Store multiple benchmark runs in a file for later comparison.
* Filter the benchmarks to execute.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #4 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the new options locally:

```
$ python3 -m hoomd_benchmarks --device CPU -N 10000 --output test.csv --name "CPU"
$ python3 -m hoomd_benchmarks --device GPU -N 10000 --output test.csv --name "GPU" -v
< output snipped>
                                        CPU           GPU
HPMCSphere                     7.956344e+01  2.036270e+03
MDPairLJ                       7.769376e+01  2.130738e+03
MDPairWCA                      3.959149e+02  7.783676e+03
MicrobenchmarkEmptySimulation  2.272727e+07  2.222222e+07
MicrobenchmarkCustomTrigger    2.680965e+06  2.597403e+06
MicrobenchmarkCustomUpdater    5.847953e+06  5.263158e+06
MicrobenchmarkGetSnapshot      8.428832e+02  7.848604e+02
MicrobenchmarkSetSnapshot      9.335194e+02  3.428912e+02
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
