### PR TITLE
Fix --output when used with --repeat.

### DIFF
--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -65,7 +65,11 @@ for benchmark_class in benchmark_classes:
             print(f'{name}: {numpy.mean(performance[name])}')
 
 if args.output is not None and benchmark_args['device'].communicator.rank == 0:
-    df = pandas.DataFrame.from_dict(performance,
+    performance_mean = {}
+    for name, performance_list in performance.items():
+        performance_mean[name] = numpy.mean(performance_list)
+
+    df = pandas.DataFrame.from_dict(performance_mean,
                                     orient='index',
                                     columns=[args.name])
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Average repeated runs before writing them to the output file.

## Motivation and context

Fixes a bug where using `--repeat` and `--output` together raised an exception.

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested locally.

```
python3 -m hoomd_benchmarks --device GPU --benchmarks "MDPairLJ*" -N 10000 --output test.csv --name "GPU" -v --repeat 10 
Using existing initial_configuration_cache/hard_sphere_10000_1.0_3.gsd
Running MDPairLJ benchmark
.. autotuning GPU kernel parameters for 1000 steps
.. running for 1000 steps 10 time(s)
.. 2120.95824893687 time steps per second
.. 2002.6033843997195 time steps per second
.. 2015.7266997111462 time steps per second
.. 1908.1092736018807 time steps per second
.. 1802.682030324717 time steps per second
.. 1771.1685638833935 time steps per second
.. 1730.7446009422174 time steps per second
.. 2133.351537933124 time steps per second
.. 2160.723237281983 time steps per second
.. 2163.9962952383426 time steps per second
                  GPU
MDPairLJ  1981.006387


```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
