### PR TITLE
Custom force benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ microbenchmark.
 * `microbenchmark_empty_simulation` - Measure the time per step with an empty Simulation object.
 * `microbenchmark_custom_trigger` - Measure the time taken per step to evaluate a custom trigger.
 * `microbenchmark_custom_updater` - Measure the time taken per step to call a custom updater.
-* `microbenchmark_custom_force` - Measure the time taken per step to use a custom force.
+* `microbenchmark_custom_force` - Measure the time taken per step to use a constant custom force.
 * `microbenchmark_get_snapshot` - Measure the time taken to call State.get_snapshot.
 * `microbenchmark_set_snapshot` - Measure the time taken to call State.set_snapshot.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ microbenchmark.
 * `microbenchmark_empty_simulation` - Measure the time per step with an empty Simulation object.
 * `microbenchmark_custom_trigger` - Measure the time taken per step to evaluate a custom trigger.
 * `microbenchmark_custom_updater` - Measure the time taken per step to call a custom updater.
+* `microbenchmark_custom_force` - Measure the time taken per step to use a custom force.
 * `microbenchmark_get_snapshot` - Measure the time taken to call State.get_snapshot.
 * `microbenchmark_set_snapshot` - Measure the time taken to call State.set_snapshot.
 

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -16,6 +16,7 @@ from .md_pair_wca import MDPairWCA
 from .microbenchmark_empty_simulation import MicrobenchmarkEmptySimulation
 from .microbenchmark_custom_trigger import MicrobenchmarkCustomTrigger
 from .microbenchmark_custom_updater import MicrobenchmarkCustomUpdater
+from .microbenchmark_custom_force import MicrobenchmarkCustomForce
 from .microbenchmark_get_snapshot import MicrobenchmarkGetSnapshot
 from .microbenchmark_set_snapshot import MicrobenchmarkSetSnapshot
 
@@ -26,6 +27,7 @@ benchmark_classes = [
     MicrobenchmarkEmptySimulation,
     MicrobenchmarkCustomTrigger,
     MicrobenchmarkCustomUpdater,
+    MicrobenchmarkCustomForce,
     MicrobenchmarkGetSnapshot,
     MicrobenchmarkSetSnapshot,
 ]

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -48,7 +48,7 @@ class MicrobenchmarkCustomForce(common.ComparativeBenchmark):
         sim1.operations.integrator = hoomd.md.Integrator(
             dt=0.001, methods=[hoomd.md.methods.NVE(filter=hoomd.filter.All())])
 
-        empty_custom_force = EmptyCustomForce()
+        empty_custom_force = EmptyForce()
         sim1.operations.integrator.forces.append(empty_custom_force)
 
         return sim0, sim1

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2021-2022 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
 import hoomd
 from . import common
 from .configuration.hard_sphere import make_hard_sphere_configuration

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -15,17 +15,6 @@ except ImportError:
     CUPY_IMPORTED = False
 
 
-class EmptyForce(hoomd.md.force.Custom):
-    """Custom force which calls an empty set_forces method."""
-
-    def __init__(self):
-        super().__init__()
-
-    def set_forces(self, timestep):
-        """Set the forces."""
-        pass
-
-
 class ConstantForce(hoomd.md.force.Custom):
     """Custom force which implements the force of gravity."""
 
@@ -82,9 +71,6 @@ class MicrobenchmarkCustomForce(common.ComparativeBenchmark):
         sim0.operations.tuners.clear()
         sim0.operations.integrator = hoomd.md.Integrator(
             dt=0.001, methods=[hoomd.md.methods.NVE(filter=hoomd.filter.All())])
-
-        empty_custom_force = EmptyForce()
-        sim0.operations.integrator.forces.append(empty_custom_force)
 
         sim1 = hoomd.Simulation(device=self.device, seed=100)
         sim1.create_state_from_gsd(filename=str(path))

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2021-2022 The Regents of the University of Michigan
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
+"""Custom Force benchmark."""
+
 import hoomd
 from . import common
 from .configuration.hard_sphere import make_hard_sphere_configuration
@@ -13,6 +15,7 @@ class EmptyForce(hoomd.md.force.Custom):
         super().__init__()
 
     def set_forces(self, timestep):
+        """Set the forces."""
         pass
 
 

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -1,0 +1,55 @@
+import hoomd
+from . import common
+from .configuration.hard_sphere import make_hard_sphere_configuration
+
+
+class EmptyForce(hoomd.md.force.Custom):
+    """Custom force which calls an empty set_forces method."""
+
+    def __init__(self):
+        super().__init__()
+
+    def set_forces(self, timestep):
+        pass
+
+
+class MicrobenchmarkCustomForce(common.ComparativeBenchmark):
+    """Measure the overhead of using a custom force.
+
+    This benchmark performs an
+    """
+
+    def make_simulations(self):
+        """Make the simulation objects."""
+        path = make_hard_sphere_configuration(N=self.N,
+                                              rho=self.rho,
+                                              dimensions=self.dimensions,
+                                              device=self.device,
+                                              verbose=self.verbose)
+
+        sim0 = hoomd.Simulation(device=self.device, seed=100)
+        sim0.create_state_from_gsd(filename=str(path))
+        sim0.operations.updaters.clear()
+        sim0.operations.computes.clear()
+        sim0.operations.writers.clear()
+        sim0.operations.tuners.clear()
+        sim0.operations.integrator = hoomd.md.Integrator(
+            dt=0.001, methods=[hoomd.md.methods.NVE(filter=hoomd.filter.All())])
+
+        sim1 = hoomd.Simulation(device=self.device, seed=100)
+        sim1.create_state_from_gsd(filename=str(path))
+        sim1.operations.updaters.clear()
+        sim1.operations.computes.clear()
+        sim1.operations.writers.clear()
+        sim1.operations.tuners.clear()
+        sim1.operations.integrator = hoomd.md.Integrator(
+            dt=0.001, methods=[hoomd.md.methods.NVE(filter=hoomd.filter.All())])
+
+        empty_custom_force = EmptyCustomForce()
+        sim1.operations.integrator.forces.append(empty_custom_force)
+
+        return sim0, sim1
+
+
+if __name__ == '__main__':
+    MicrobenchmarkCustomForce.main()

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -48,7 +48,7 @@ class ConstantForce(hoomd.md.force.Custom):
         with getattr(self, self._local_force_str) as arrays, getattr(
                 self._state, self._local_snapshot_str) as snap:
             arrays.force[:] = self._to_array([0, 0, -self._mag])
-            arrays.potential_energy[:] = cp.array(
+            arrays.potential_energy[:] = self._to_array(
                 snap.particles.position[:, 2]) * self._mag
 
 


### PR DESCRIPTION
## Description

This PR adds a benchmark to determine the overhead of the python callback needed for custom forces in hoomd v3

## Motivation and context

hoomd v3 recent had custom forces added and its important to get an idea of how much faster or slower custom forces are compared to typical force computes implemented directly in C++.

## How has this been tested?

The CI should run all the benchmarks and if the output looks right then it should be good

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
