### PR TITLE
Add flag to enable/disable long range corrections

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 The following individuals have contributed to `hoomd-benchmarks`:
 
 * Joshua A. Anderson - University of Michigan
+* Tim Moore - University of Michigan

--- a/hoomd_benchmarks/md_pair.py
+++ b/hoomd_benchmarks/md_pair.py
@@ -9,6 +9,7 @@ from .configuration.hard_sphere import make_hard_sphere_configuration
 
 DEFAULT_BUFFER = 0.4
 DEFAULT_REBUILD_CHECK_DELAY = 1
+DEFAULT_TAIL_CORRECTION = False
 
 
 class MDPair(common.Benchmark):
@@ -32,9 +33,11 @@ class MDPair(common.Benchmark):
     def __init__(self,
                  buffer=DEFAULT_BUFFER,
                  rebuild_check_delay=DEFAULT_REBUILD_CHECK_DELAY,
+                 tail_correction=DEFAULT_TAIL_CORRECTION,
                  **kwargs):
         self.buffer = buffer
         self.rebuild_check_delay = rebuild_check_delay
+        self.tail_correction = tail_correction
         super().__init__(**kwargs)
 
     @staticmethod
@@ -49,6 +52,9 @@ class MDPair(common.Benchmark):
                             type=int,
                             default=DEFAULT_REBUILD_CHECK_DELAY,
                             help='Neighbor list rebuild check delay.')
+        parser.add_argument('--tail_correction',
+                            action='store_true',
+                            help='Enable integrated isotropic tail correction.')
         return parser
 
     def make_simulation(self):
@@ -63,7 +69,7 @@ class MDPair(common.Benchmark):
         cell = hoomd.md.nlist.Cell(buffer=self.buffer)
         cell.rebuild_check_delay = self.rebuild_check_delay
 
-        pair = self.pair_class(nlist=cell)
+        pair = self.pair_class(nlist=cell, tail_correction=self.tail_correction)
         pair.params[('A', 'A')] = self.pair_params
         pair.r_cut[('A', 'A')] = self.r_cut
         integrator.forces.append(pair)


### PR DESCRIPTION
## Description

Adds a flag to enable/disable the long-range corrections to the energy and pressure for a given pair potential. This is useful for benchmarking the performance penalty when using the corrections (which should be minimal given their analytical form).

This is currently specific to the Lennard-Jones benchmark since it is the only pair potential with the correction implemented. 

## Motivation and context

This was helpful in benchmarking the long-range corrections for the LJ pair potential, and led us to find a GPU memory issue (see [the discussion on the PR](https://github.com/glotzerlab/hoomd-blue/pull/1138#issuecomment-1024431836) for more information).

## How has this been tested?

Manually.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
