### PR TITLE
Improve release performance regression check process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The full suite accepts the following command line options in addition to the com
 
 * `--benchmarks`: Select the benchmarks to run by class name using `fnmatch` syntax.
 * `--output`: Add column of benchmark results to or create the output CSV file.
-* `--name`: Name identifying this benchmark run.
+* `--name`: Name identifying this benchmark run (leave unset to use the HOOMD-blue version).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ tests:
 
 When using the Python API, pass these options to the benchmark's constructor.
 
+When running the full benchmark suite, `benchmark_steps` and `warmup_steps` set the number of steps
+for **typical** benchmarks. Some unusually fast or slow benchmarks may scale the given value to
+a larger or smaller number of actual steps.
+
+When running individual benchmarks, `benchmark_steps`, and `warmup_steps` set the exact number of
+steps to run with no scaling.
+
 ## The benchmark suite
 
 Run the full suite with `python3 -m hoomd_benchmarks <options>`.

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -8,6 +8,7 @@ import fnmatch
 import numpy
 import os
 import pandas
+import hoomd
 
 from . import common
 from .hpmc_sphere import HPMCSphere
@@ -45,18 +46,25 @@ parser.add_argument('-o',
                     'CSV file.')
 parser.add_argument('--name',
                     type=str,
-                    help='Name identifying this benchmark run.')
+                    default=None,
+                    help='Name identifying this benchmark run'
+                         ' (leave unset to use the HOOMD-blue version).')
 args = parser.parse_args()
 
-benchmark_args = copy.deepcopy(vars(args))
-del benchmark_args['benchmarks']
-del benchmark_args['output']
-del benchmark_args['name']
-benchmark_args['device'] = common.make_hoomd_device(args)
+benchmark_args_ref = copy.deepcopy(vars(args))
+del benchmark_args_ref['benchmarks']
+del benchmark_args_ref['output']
+del benchmark_args_ref['name']
+benchmark_args_ref['device'] = common.make_hoomd_device(args)
 
 performance = {}
 
 for benchmark_class in benchmark_classes:
+    # scale the benchmark_steps by the class specific scale factor
+    benchmark_args = copy.copy(benchmark_args_ref)
+    benchmark_args['warmup_steps'] *= benchmark_class.SUITE_STEP_SCALE
+    benchmark_args['benchmark_steps'] *= benchmark_class.SUITE_STEP_SCALE
+
     name = benchmark_class.__name__
     if fnmatch.fnmatch(name, args.benchmarks):
         benchmark = benchmark_class(**benchmark_args)
@@ -71,9 +79,12 @@ if args.output is not None and benchmark_args['device'].communicator.rank == 0:
     for name, performance_list in performance.items():
         performance_mean[name] = numpy.mean(performance_list)
 
+    name = args.name
+    if name is None:
+        name = hoomd.version.version
     df = pandas.DataFrame.from_dict(performance_mean,
                                     orient='index',
-                                    columns=[args.name])
+                                    columns=[name])
 
     if os.path.isfile(args.output):
         df_old = pandas.read_csv(args.output, index_col=0)

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -48,7 +48,7 @@ parser.add_argument('--name',
                     type=str,
                     default=None,
                     help='Name identifying this benchmark run'
-                         ' (leave unset to use the HOOMD-blue version).')
+                    ' (leave unset to use the HOOMD-blue version).')
 args = parser.parse_args()
 
 benchmark_args_ref = copy.deepcopy(vars(args))

--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -66,6 +66,7 @@ class Benchmark:
         units (str): Name of the units to report on the performance (only
           shown when verbose=True.
     """
+    SUITE_STEP_SCALE=1
 
     def __init__(self,
                  device,

--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -66,7 +66,7 @@ class Benchmark:
         units (str): Name of the units to report on the performance (only
           shown when verbose=True.
     """
-    SUITE_STEP_SCALE=1
+    SUITE_STEP_SCALE = 1
 
     def __init__(self,
                  device,

--- a/hoomd_benchmarks/microbenchmark_custom_trigger.py
+++ b/hoomd_benchmarks/microbenchmark_custom_trigger.py
@@ -25,6 +25,7 @@ class MicrobenchmarkCustomTrigger(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
+    SUITE_STEP_SCALE=100
 
     def make_simulations(self):
         """Make the Simulation objects."""

--- a/hoomd_benchmarks/microbenchmark_custom_trigger.py
+++ b/hoomd_benchmarks/microbenchmark_custom_trigger.py
@@ -25,7 +25,7 @@ class MicrobenchmarkCustomTrigger(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
-    SUITE_STEP_SCALE=100
+    SUITE_STEP_SCALE = 100
 
     def make_simulations(self):
         """Make the Simulation objects."""

--- a/hoomd_benchmarks/microbenchmark_custom_updater.py
+++ b/hoomd_benchmarks/microbenchmark_custom_updater.py
@@ -22,7 +22,7 @@ class MicrobenchmarkCustomUpdater(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
-    SUITE_STEP_SCALE=100
+    SUITE_STEP_SCALE = 100
 
     def make_simulations(self):
         """Make the Simulation objects."""

--- a/hoomd_benchmarks/microbenchmark_custom_updater.py
+++ b/hoomd_benchmarks/microbenchmark_custom_updater.py
@@ -22,6 +22,7 @@ class MicrobenchmarkCustomUpdater(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
+    SUITE_STEP_SCALE=100
 
     def make_simulations(self):
         """Make the Simulation objects."""

--- a/hoomd_benchmarks/microbenchmark_empty_simulation.py
+++ b/hoomd_benchmarks/microbenchmark_empty_simulation.py
@@ -14,6 +14,7 @@ class MicrobenchmarkEmptySimulation(common.Benchmark):
     See Also:
         `common.Benchmark`
     """
+    SUITE_STEP_SCALE=100
 
     def make_simulation(self):
         """Make the Simulation object."""

--- a/hoomd_benchmarks/microbenchmark_empty_simulation.py
+++ b/hoomd_benchmarks/microbenchmark_empty_simulation.py
@@ -14,7 +14,7 @@ class MicrobenchmarkEmptySimulation(common.Benchmark):
     See Also:
         `common.Benchmark`
     """
-    SUITE_STEP_SCALE=100
+    SUITE_STEP_SCALE = 100
 
     def make_simulation(self):
         """Make the Simulation object."""

--- a/hoomd_benchmarks/microbenchmark_get_snapshot.py
+++ b/hoomd_benchmarks/microbenchmark_get_snapshot.py
@@ -28,7 +28,7 @@ class MicrobenchmarkGetSnapshot(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
-    SUITE_STEP_SCALE=0.01
+    SUITE_STEP_SCALE = 0.01
 
     def make_simulations(self):
         """Make the Simulation objects."""

--- a/hoomd_benchmarks/microbenchmark_get_snapshot.py
+++ b/hoomd_benchmarks/microbenchmark_get_snapshot.py
@@ -28,6 +28,7 @@ class MicrobenchmarkGetSnapshot(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
+    SUITE_STEP_SCALE=0.01
 
     def make_simulations(self):
         """Make the Simulation objects."""

--- a/hoomd_benchmarks/microbenchmark_set_snapshot.py
+++ b/hoomd_benchmarks/microbenchmark_set_snapshot.py
@@ -31,6 +31,7 @@ class MicrobenchmarkSetSnapshot(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
+    SUITE_STEP_SCALE=0.01
 
     def make_simulations(self):
         """Make the Simulation objects."""

--- a/hoomd_benchmarks/microbenchmark_set_snapshot.py
+++ b/hoomd_benchmarks/microbenchmark_set_snapshot.py
@@ -31,7 +31,7 @@ class MicrobenchmarkSetSnapshot(common.ComparativeBenchmark):
     See Also:
         `common.ComparativeBenchmark`
     """
-    SUITE_STEP_SCALE=0.01
+    SUITE_STEP_SCALE = 0.01
 
     def make_simulations(self):
         """Make the Simulation objects."""


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
* Adjust number of steps run in full suite.
* Default name to hoomd verison.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Some benchmarks run so fast they need to run more steps to get better sampling. Others are so slow they need to run fewer steps so the full suite doesn't take too long to run.

Default the name to the HOOMD version to reduce the chance for error when performing performance regression checks between two HOOMD releases.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested these changes locally.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
