### PR TITLE
Allow benchmarks to run when there is no cupy.

### DIFF
--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -242,6 +242,7 @@ class ComparativeBenchmark(Benchmark):
         if self.skip_reference:
             return self.compare_sim.tps
 
+        # Avoid divide by zero errors when the simulation is not executed.
         if self.reference_sim.tps == 0:
             return 0
 

--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -242,6 +242,9 @@ class ComparativeBenchmark(Benchmark):
         if self.skip_reference:
             return self.compare_sim.tps
 
+        if self.reference_sim.tps == 0:
+            return 0
+
         t0 = 1 / self.reference_sim.tps
         t1 = 1 / self.compare_sim.tps
         return 1 / (t1 - t0)


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Allow benchmarks to run when there is no cupy.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Users need to take extra steps to install cupy. Allow the benchmarks to complete without error when cupy is not installed. Those benchmarks that require cupy will not produce meaningful output.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested this locally.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
