### PR TITLE
Continue the warm up phase until autotuning completes.

### DIFF
--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -119,11 +119,12 @@ class Benchmark:
             print(f'.. warming up for {self.warmup_steps} steps')
         self.run(self.warmup_steps)
 
-        if (isinstance(self.device, hoomd.device.GPU) and hasattr(self.sim.operations, 'is_tuning_complete')):
+        if (isinstance(self.device, hoomd.device.GPU)
+                and hasattr(self.sim.operations, 'is_tuning_complete')):
             while not self.sim.operations.is_tuning_complete:
                 if print_verbose_messages:
                     print('.. autotuning GPU kernel parameters for '
-                        f'{self.warmup_steps} steps')
+                          f'{self.warmup_steps} steps')
                 self.run(self.warmup_steps)
 
         if print_verbose_messages:

--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -110,7 +110,7 @@ class Benchmark:
                                   and self.device.communicator.rank == 0)
 
         # Ensure that all ops are attached (needed for is_tuning_complete).
-        self.sim.run(0)
+        self.run(0)
 
         if print_verbose_messages:
             print(f'Running {type(self).__name__} benchmark')

--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -109,20 +109,22 @@ class Benchmark:
         print_verbose_messages = (self.verbose
                                   and self.device.communicator.rank == 0)
 
+        # Ensure that all ops are attached (needed for is_tuning_complete).
+        self.sim.run(0)
+
         if print_verbose_messages:
             print(f'Running {type(self).__name__} benchmark')
 
-        if isinstance(self.device, hoomd.device.GPU):
-            if print_verbose_messages:
-                print('.. autotuning GPU kernel parameters for '
-                      f'{self.warmup_steps} steps')
-            self.run(self.warmup_steps)
-            # TODO: Run until autotuning is complete when the autotuning API is
-            # implemented.
-        else:
-            if print_verbose_messages:
-                print(f'.. warming up for {self.warmup_steps} steps')
-            self.run(self.warmup_steps)
+        if print_verbose_messages:
+            print(f'.. warming up for {self.warmup_steps} steps')
+        self.run(self.warmup_steps)
+
+        if (isinstance(self.device, hoomd.device.GPU) and hasattr(self.sim.operations, 'is_tuning_complete')):
+            while not self.sim.operations.is_tuning_complete:
+                if print_verbose_messages:
+                    print('.. autotuning GPU kernel parameters for '
+                        f'{self.warmup_steps} steps')
+                self.run(self.warmup_steps)
 
         if print_verbose_messages:
             print(f'.. running for {self.benchmark_steps} steps '

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -57,7 +57,6 @@ class MicrobenchmarkCustomForce(common.ComparativeBenchmark):
                           " - cupy is not available.")
             return [0]
 
-
     def make_simulations(self):
         """Make the simulation objects."""
         path = make_hard_sphere_configuration(N=self.N,

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -5,6 +5,7 @@
 
 import hoomd
 import numpy as np
+import warnings
 from . import common
 from .configuration.hard_sphere import make_hard_sphere_configuration
 
@@ -47,13 +48,15 @@ class MicrobenchmarkCustomForce(common.ComparativeBenchmark):
     This benchmark performs an
     """
 
-    def run(self, steps):
-        """Override run so this benchmark is skipped without cupy installed."""
+    def execute(self):
+        """Override execute to skip this benchamrk without cupy installed."""
         if isinstance(self.device, hoomd.device.CPU) or CUPY_IMPORTED:
-            super().run(steps)
+            return super().execute()
         else:
-            print("Skipping microbenchmark_custom_force on GPU device because "
-                  "cupy is not available.")
+            warnings.warn("Skipping microbenchmark_custom_force on GPU device "
+                          " - cupy is not available.")
+            return [0]
+
 
     def make_simulations(self):
         """Make the simulation objects."""


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Continue the warm up phase until autotuning completes. Use `hasattr` to support v3.0-v3.3 releases that lack this feature.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Ensure that kernel performance autotuning is complete before measuring performance. This helps the stabilize the performance measurements and makes them relevant to long running simulations that spend very little time (relatively) autotuning.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested individual benchmarks and the full suite locally:
```
python3 -m hoomd_benchmarks.md_pair_lj -v --device GPU                                                                   [warmup-until-autotuned]
Using existing initial_configuration_cache/hard_sphere_64000_1.0_3.gsd
Running MDPairLJ benchmark
.. warming up for 1000 steps
.. autotuning GPU kernel parameters for 1000 steps
.. autotuning GPU kernel parameters for 1000 steps
.. autotuning GPU kernel parameters for 1000 steps
.. autotuning GPU kernel parameters for 1000 steps
.. running for 1000 steps 1 time(s)
.. 467.05968182026237 time steps per second
467.05968182026237
```
```
python3 -m hoomd_benchmarks --device GPU                                                                                 [warmup-until-autotuned]
HPMCSphere: 560.269523256858
MDPairLJ: 462.59374462234774
MDPairWCA: 2369.892880841786
MicrobenchmarkEmptySimulation: 25920165.88906169
MicrobenchmarkCustomTrigger: 3665151.737281924
MicrobenchmarkCustomUpdater: 6777822.9632642
/home/joaander/devel/hoomd-benchmarks/hoomd_benchmarks/microbenchmark_custom_force.py:56: UserWarning: Skipping microbenchmark_custom_force on GPU device  - cupy is not available.
  warnings.warn("Skipping microbenchmark_custom_force on GPU device "
MicrobenchmarkCustomForce: 0.0
MicrobenchmarkGetSnapshot: 131.58067869314073
MicrobenchmarkSetSnapshot: 124.83615254977842
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
