### PR TITLE
Add n_types option to MDPair benchmarks.

### DIFF
--- a/hoomd_benchmarks/configuration/hard_sphere.py
+++ b/hoomd_benchmarks/configuration/hard_sphere.py
@@ -11,7 +11,12 @@ import math
 import itertools
 
 
-def make_hard_sphere_configuration(N, rho, dimensions, device, verbose, n_types=1):
+def make_hard_sphere_configuration(N,
+                                   rho,
+                                   dimensions,
+                                   device,
+                                   verbose,
+                                   n_types=1):
     """Make an initial configuration of hard spheres, or find it in the cache.
 
     Args:
@@ -32,7 +37,8 @@ def make_hard_sphere_configuration(N, rho, dimensions, device, verbose, n_types=
     print_messages = verbose and device.communicator.rank == 0
 
     if n_types > 1:
-        one_type_path = make_hard_sphere_configuration(N, rho, dimensions, device, verbose, 1)
+        one_type_path = make_hard_sphere_configuration(N, rho, dimensions,
+                                                       device, verbose, 1)
 
         filename = f'hard_sphere_{N}_{rho}_{dimensions}_{n_types}.gsd'
         file_path = pathlib.Path('initial_configuration_cache') / filename
@@ -44,8 +50,10 @@ def make_hard_sphere_configuration(N, rho, dimensions, device, verbose, n_types=
         if device.communicator.rank == 0:
             with gsd.hoomd.open(one_type_path, mode='rb') as one_type_gsd:
                 snapshot = one_type_gsd[0]
-                snapshot.particles.types = [str(i) for i in range(0,n_types)]
-                snapshot.particles.typeid = [i % n_types for i in range(0,snapshot.particles.N)]
+                snapshot.particles.types = [str(i) for i in range(0, n_types)]
+                snapshot.particles.typeid = [
+                    i % n_types for i in range(0, snapshot.particles.N)
+                ]
 
                 with gsd.hoomd.open(file_path, mode='wb') as n_types_gsd:
                     n_types_gsd.append(snapshot)

--- a/hoomd_benchmarks/md_pair.py
+++ b/hoomd_benchmarks/md_pair.py
@@ -35,7 +35,7 @@ class MDPair(common.Benchmark):
                  buffer=DEFAULT_BUFFER,
                  rebuild_check_delay=DEFAULT_REBUILD_CHECK_DELAY,
                  tail_correction=DEFAULT_TAIL_CORRECTION,
-                 n_types = DEFAULT_N_TYPES,
+                 n_types=DEFAULT_N_TYPES,
                  **kwargs):
         self.buffer = buffer
         self.rebuild_check_delay = rebuild_check_delay


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add `n_types` option to MD pair benchmarks. This creates a system configuration with the given number of types.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow synthetic and comparable benchmarks with a varying number of types. Used to test changes in HOOMD-blue.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the n_types option locally.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
