### PR TITLE
Add `pair.Table` benchmark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ report performance in time steps per second (MD) and trial moves per second per 
 * `hpmc_sphere` - Hard particle Monte Carlo simulation of spheres (diameter=1.0, d=0.1).
 * `md_pair_lj` - Molecular dynamics simulation with the Lennard-Jones pair potential with the NVT
   integration method (epsilon=1, sigma=1, r_cut=2.5, kT=1.2, tau=0.5).
+* `md_pair_table` - Molecular dynamics simulation with the Lennard-Jones pair potential with the NVT
+  integration method (epsilon=1, sigma=1, r_cut=2.5, kT=1.2, tau=0.5) - evaluated using
+  ``hoomd.md.pair.Table``.
 * `md_pair_wca` - Molecular dynamics simulation with the WCA pair potential with the NVT
   integration method (epsilon=1, sigma=1, r_cut=2**(1/6), kT=1.2, tau=0.5).
 

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -13,6 +13,7 @@ import hoomd
 from . import common
 from .hpmc_sphere import HPMCSphere
 from .md_pair_lj import MDPairLJ
+from .md_pair_table import MDPairTable
 from .md_pair_wca import MDPairWCA
 from .microbenchmark_empty_simulation import MicrobenchmarkEmptySimulation
 from .microbenchmark_custom_trigger import MicrobenchmarkCustomTrigger
@@ -24,6 +25,7 @@ from .microbenchmark_set_snapshot import MicrobenchmarkSetSnapshot
 benchmark_classes = [
     HPMCSphere,
     MDPairLJ,
+    MDPairTable,
     MDPairWCA,
     MicrobenchmarkEmptySimulation,
     MicrobenchmarkCustomTrigger,

--- a/hoomd_benchmarks/md_pair.py
+++ b/hoomd_benchmarks/md_pair.py
@@ -81,7 +81,8 @@ class MDPair(common.Benchmark):
         sim.create_state_from_gsd(filename=str(path))
 
         if self.pair_class is hoomd.md.pair.LJ:
-            pair = self.pair_class(nlist=cell, tail_correction=self.tail_correction)
+            pair = self.pair_class(nlist=cell,
+                                   tail_correction=self.tail_correction)
         else:
             pair = self.pair_class(nlist=cell)
 

--- a/hoomd_benchmarks/md_pair.py
+++ b/hoomd_benchmarks/md_pair.py
@@ -80,7 +80,11 @@ class MDPair(common.Benchmark):
         sim = hoomd.Simulation(device=self.device)
         sim.create_state_from_gsd(filename=str(path))
 
-        pair = self.pair_class(nlist=cell, tail_correction=self.tail_correction)
+        if self.pair_class is hoomd.md.pair.LJ:
+            pair = self.pair_class(nlist=cell, tail_correction=self.tail_correction)
+        else:
+            pair = self.pair_class(nlist=cell)
+
         particle_types = sim.state.particle_types
         pair.params[(particle_types, particle_types)] = self.pair_params
         pair.r_cut[(particle_types, particle_types)] = self.r_cut

--- a/hoomd_benchmarks/md_pair_table.py
+++ b/hoomd_benchmarks/md_pair_table.py
@@ -12,11 +12,16 @@ EVAL_POINTS = 200
 R_MIN = 0.5
 DEFAULT_R_CUT = 2.5
 
+
 def lj_energy(r):
-    return 4 * ((1/r)**12 - (1/r)**6)
+    """Compute LJ energy."""
+    return 4 * ((1 / r)**12 - (1 / r)**6)
+
 
 def lj_force(r):
+    """Compute LJ force."""
     return 24 * (2 - r**6) / r**13
+
 
 class MDPairTable(md_pair.MDPair):
     """Molecular dynamics Table pair potential benchmark.

--- a/hoomd_benchmarks/md_pair_table.py
+++ b/hoomd_benchmarks/md_pair_table.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2021-2022 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Table pair potential benchmark."""
+
+import hoomd
+from . import md_pair
+
+import numpy
+
+EVAL_POINTS = 200
+R_MIN = 0.5
+DEFAULT_R_CUT = 2.5
+
+def lj_energy(r):
+    return 4 * ((1/r)**12 - (1/r)**6)
+
+def lj_force(r):
+    return 24 * (2 - r**6) / r**13
+
+class MDPairTable(md_pair.MDPair):
+    """Molecular dynamics Table pair potential benchmark.
+
+    See Also:
+        `md_pair.MDPair`
+    """
+    pair_class = hoomd.md.pair.Table
+
+    r = numpy.linspace(R_MIN, DEFAULT_R_CUT, EVAL_POINTS, endpoint=False)
+
+    pair_params = dict(r_min=R_MIN, U=lj_energy(r), F=lj_force(r))
+    r_cut = DEFAULT_R_CUT
+
+
+if __name__ == '__main__':
+    MDPairTable.main()


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
A a benchmark to evaluate the performance of `pair.Table`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
I noticed slow performance in `pair.Table` on the CPU. This benchmark evaluates that and ensures that we check for performance regressions going forward.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I ran this benchmark locally on HOOMD-blue builds.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
