### PR TITLE
Add options to pair force benchmarks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 ci:
   autoupdate_schedule: quarterly
+  autofix_prs: false
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/hoomd_benchmarks/md_pair.py
+++ b/hoomd_benchmarks/md_pair.py
@@ -99,7 +99,8 @@ class MDPair(common.Benchmark):
         particle_types = sim.state.particle_types
         pair.params[(particle_types, particle_types)] = self.pair_params
         pair.r_cut[(particle_types, particle_types)] = self.r_cut
-        pair.r_on[(particle_types, particle_types)] = self.r_cut * 0.9
+        if hasattr(pair, 'r_on'):
+            pair.r_on[(particle_types, particle_types)] = self.r_cut * 0.9
         pair.mode = self.mode
         integrator.forces.append(pair)
         nvt = hoomd.md.methods.NVT(kT=1.2, filter=hoomd.filter.All(), tau=0.5)

--- a/hoomd_benchmarks/md_pair.py
+++ b/hoomd_benchmarks/md_pair.py
@@ -70,9 +70,7 @@ class MDPair(common.Benchmark):
         parser.add_argument('--always_compute_pressure',
                             action='store_true',
                             help='Always compute pressure.')
-        parser.add_argument('--mode',
-                            default=DEFAULT_MODE,
-                            help='Shift mode.')
+        parser.add_argument('--mode', default=DEFAULT_MODE, help='Shift mode.')
         return parser
 
     def make_simulation(self):


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add:
* `--mode`
* `--always_compute_pressure`
command line options to the pair force benchmarks.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This enables profiling of the alternate code paths in the pair potential kernels.

## How has this been tested?

I ran this locally in nsight compute and observed the line level profiling details for the XPLOR shifting mode and the virial computation.

<!--- Please describe in detail how you tested your changes. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
