### PR TITLE
OPP benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ report performance in time steps per second (MD) and trial moves per second per 
 * `hpmc_sphere` - Hard particle Monte Carlo simulation of spheres (diameter=1.0, d=0.1).
 * `md_pair_lj` - Molecular dynamics simulation with the Lennard-Jones pair potential with the NVT
   integration method (epsilon=1, sigma=1, r_cut=2.5, kT=1.2, tau=0.5).
+* `md_pair_opp` - Molecular dynamics simulation with theOPP pair potential with the NVT
+  integration method (C1=1.7925807855607998, C2=1.7925807855607998, eta1=15, eta2=3, k=7.0,
+  phi=5.5, r_cut=2.557, kT=1.2, tau=0.5).
 * `md_pair_table` - Molecular dynamics simulation with the Lennard-Jones pair potential with the NVT
   integration method (epsilon=1, sigma=1, r_cut=2.5, kT=1.2, tau=0.5) - evaluated using
   ``hoomd.md.pair.Table``.

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -13,6 +13,7 @@ import hoomd
 from . import common
 from .hpmc_sphere import HPMCSphere
 from .md_pair_lj import MDPairLJ
+from .md_pair_opp import MDPairOPP
 from .md_pair_table import MDPairTable
 from .md_pair_wca import MDPairWCA
 from .microbenchmark_empty_simulation import MicrobenchmarkEmptySimulation
@@ -25,6 +26,7 @@ from .microbenchmark_set_snapshot import MicrobenchmarkSetSnapshot
 benchmark_classes = [
     HPMCSphere,
     MDPairLJ,
+    MDPairOPP,
     MDPairTable,
     MDPairWCA,
     MicrobenchmarkEmptySimulation,

--- a/hoomd_benchmarks/md_pair_opp.py
+++ b/hoomd_benchmarks/md_pair_opp.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2021-2022 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""OPP pair potential benchmark."""
+
+import hoomd
+from . import md_pair
+
+
+class MDPairOPP(md_pair.MDPair):
+    """Molecular dynamics OPP pair potential benchmark.
+
+    See Also:
+        `md_pair.MDPair`
+    """
+    pair_class = hoomd.md.pair.OPP
+    pair_params = dict({'C1': 1.7925807855607998, 'C2': 1.7925807855607998, 'eta1': 15, 'eta2': 3, 'k': 7.0, 'phi': 5.5})
+    r_cut = 2.557
+
+
+if __name__ == '__main__':
+    MDPairOPP.main()

--- a/hoomd_benchmarks/md_pair_opp.py
+++ b/hoomd_benchmarks/md_pair_opp.py
@@ -14,7 +14,14 @@ class MDPairOPP(md_pair.MDPair):
         `md_pair.MDPair`
     """
     pair_class = hoomd.md.pair.OPP
-    pair_params = dict({'C1': 1.7925807855607998, 'C2': 1.7925807855607998, 'eta1': 15, 'eta2': 3, 'k': 7.0, 'phi': 5.5})
+    pair_params = dict({
+        'C1': 1.7925807855607998,
+        'C2': 1.7925807855607998,
+        'eta1': 15,
+        'eta2': 3,
+        'k': 7.0,
+        'phi': 5.5
+    })
     r_cut = 2.557
 
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add benchmark for ``md.pair.OPP``.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Measure the performance of a typical OPP system. Use to profile code and check for performance regressions on release.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested the benchmark locally.

```
$ python3 -m hoomd_benchmarks --device GPU
HPMCSphere: 900.2074978282494
MDPairLJ: 2622.2355082154636
MDPairOPP: 1333.8989064696766
...
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
