### PR TITLE
Add box resize microbenchmark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ report performance in time steps per second (MD) and trial moves per second per 
 Microbenchmarks exercise a portion of the code and report performance with a metric specific to each
 microbenchmark.
 
+* `microbenchmark_box_reisze` - Measure the time steps per second of a sim with only box resize.
 * `microbenchmark_empty_simulation` - Measure the time per step with an empty Simulation object.
 * `microbenchmark_custom_trigger` - Measure the time taken per step to evaluate a custom trigger.
 * `microbenchmark_custom_updater` - Measure the time taken per step to call a custom updater.

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -16,6 +16,7 @@ from .md_pair_lj import MDPairLJ
 from .md_pair_opp import MDPairOPP
 from .md_pair_table import MDPairTable
 from .md_pair_wca import MDPairWCA
+from .microbenchmark_box_resize import MicrobenchmarkBoxResize
 from .microbenchmark_empty_simulation import MicrobenchmarkEmptySimulation
 from .microbenchmark_custom_trigger import MicrobenchmarkCustomTrigger
 from .microbenchmark_custom_updater import MicrobenchmarkCustomUpdater
@@ -29,6 +30,7 @@ benchmark_classes = [
     MDPairOPP,
     MDPairTable,
     MDPairWCA,
+    MicrobenchmarkBoxResize,
     MicrobenchmarkEmptySimulation,
     MicrobenchmarkCustomTrigger,
     MicrobenchmarkCustomUpdater,

--- a/hoomd_benchmarks/microbenchmark_box_resize.py
+++ b/hoomd_benchmarks/microbenchmark_box_resize.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2021-2022 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Box resize benchmark."""
+
+import hoomd
+from . import common
+from .configuration.hard_sphere import make_hard_sphere_configuration
+
+
+class MicrobenchmarkBoxResize(common.Benchmark):
+    """Measure the performance of the box resize updater.
+
+    See Also:
+        `common.Benchmark`
+    """
+
+    def make_simulation(self):
+        """Make the Simulation object."""
+        path = make_hard_sphere_configuration(N=self.N,
+                                              rho=self.rho,
+                                              dimensions=self.dimensions,
+                                              device=self.device,
+                                              verbose=self.verbose)
+
+        sim = hoomd.Simulation(device=self.device, seed=100)
+        sim.create_state_from_gsd(filename=str(path))
+        sim.operations.updaters.clear()
+        sim.operations.computes.clear()
+        sim.operations.writers.clear()
+        sim.operations.tuners.clear()
+
+        box_resize_trigger = hoomd.trigger.Periodic(1)
+        initial_box = sim.state.box
+        final_box = hoomd.Box.from_box(initial_box)
+        final_box.volume = initial_box.volume / 2
+
+        ramp = hoomd.variant.Ramp(A=0,
+                                  B=1,
+                                  t_start=sim.timestep,
+                                  t_ramp=self.warmup_steps * 10
+                                  + self.repeat * self.benchmark_steps)
+        box_resize = hoomd.update.BoxResize(box1=initial_box,
+                                            box2=final_box,
+                                            variant=ramp,
+                                            trigger=box_resize_trigger)
+        sim.operations.updaters.append(box_resize)
+
+        return sim
+
+
+if __name__ == '__main__':
+    MicrobenchmarkBoxResize.main()

--- a/hoomd_benchmarks/microbenchmark_box_resize.py
+++ b/hoomd_benchmarks/microbenchmark_box_resize.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 The Regents of the University of Michigan
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
 # Part of HOOMD-blue, released under the BSD 3-Clause License.
 
 """Box resize benchmark."""


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add `MicrobenchmarkBoxResize`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Measure the performance improvements made in https://github.com/glotzerlab/hoomd-blue/pull/1462.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I tested that both `python3 -m hoomd_benchmarks.microbenchmark_box_resize` and `python3 -m hoomd_benchmarks` produce the expected output.

On trunk-patch:
```
python3 -m hoomd_benchmarks.microbenchmark_box_resize --device CPU --repeat 10 -v
Using existing initial_configuration_cache/hard_sphere_64000_1.0_3.gsd         
Running MicrobenchmarkBoxResize benchmark                                                                                             
.. warming up for 1000 steps                                                                                                          
.. running for 1000 steps 10 time(s)                                                                                                  
.. 676.5007323120427 time steps per second                                                                                            
.. 680.5735056817679 time steps per second                                                                                            
.. 683.9571022105494 time steps per second                                                                                            
.. 677.9284134712511 time steps per second                                                                                            
.. 678.8921566231361 time steps per second                         
.. 683.8083750114538 time steps per second                       
.. 678.9571489774565 time steps per second                                                                                            
.. 678.7212077979636 time steps per second      
.. 683.4382411033426 time steps per second
.. 677.0480704129993 time steps per second
679.9824953601963
$ python3 -m hoomd_benchmarks.microbenchmark_box_resize --device GPU --repeat 10 -v
Using existing initial_configuration_cache/hard_sphere_64000_1.0_3.gsd                           
Running MicrobenchmarkBoxResize benchmark                                                                                             
.. warming up for 1000 steps
.. running for 1000 steps 10 time(s)                                                                                                  
.. 693.8503350950193 time steps per second                                                                                            
.. 692.1066619418852 time steps per second                                                                                            
.. 696.0356592988971 time steps per second                                                                                            
.. 689.5301059187195 time steps per second                                                                                            
.. 685.7059788761417 time steps per second                                                                                            
.. 694.4844737578625 time steps per second                                                                                            
.. 689.7688653509096 time steps per second
.. 692.6138276195002 time steps per second
.. 695.695246523089 time steps per second         
.. 692.0463117391815 time steps per second
692.1837466121206
```

On `box-resize-gpu`:
```
$ python3 -m hoomd_benchmarks.microbenchmark_box_resize --device GPU --repeat 10 -v
Using existing initial_configuration_cache/hard_sphere_64000_1.0_3.gsd
Running MicrobenchmarkBoxResize benchmark                                                                                             
.. warming up for 1000 steps                                                                                                          
.. running for 1000 steps 10 time(s)                                                                                                  .. 46082.94930875576 time steps per second   
.. 39955.25011986575 time steps per second                                                                                            
.. 45884.18830870881 time steps per second
.. 45945.32506317482 time steps per second                         
.. 45848.425106597584 time steps per second                        
.. 45798.03068468056 time steps per second                                                                                            
.. 45941.10350530619 time steps per second
.. 46006.62495399338 time steps per second
.. 45947.43613306378 time steps per second
.. 46628.74195654201 time steps per second
45403.80751406886
```

```
$ python3 -m hoomd_benchmarks --device GPU                                                      
HPMCSphere: 906.4892848434085                                                                                                         
MDPairLJ: 2594.370216629913                                                                                                           
MDPairOPP: 1126.3290683005948                                                                                                         
MDPairTable: 916.1930711982799                                                                                                        
MDPairWCA: 4448.022631539149                                                                                                          
MicrobenchmarkBoxResize: 41581.77055179009                                                                                            
MicrobenchmarkEmptySimulation: 14865467.51895347                                                                                      
MicrobenchmarkCustomTrigger: 2555910.543130991                                                                                        
MicrobenchmarkCustomUpdater: 4736193.994506015                                                                                        
/home/joaander/devel/hoomd-benchmarks/hoomd_benchmarks/microbenchmark_custom_force.py:56: UserWarning: Skipping microbenchmark_custom_
force on GPU device  - cupy is not available.                    
  warnings.warn("Skipping microbenchmark_custom_force on GPU device "                
MicrobenchmarkCustomForce: 0.0                                     
MicrobenchmarkGetSnapshot: 59.81326299293605
MicrobenchmarkSetSnapshot: 49.965773445190045
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
