### PR TITLE
Add GSD benchmarks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ simulation performance between different versions, build configurations, or syst
 
 ## Requirements
 
-* HOOMD-blue v3.0-beta
+* HOOMD-blue >=3.0
 * numpy
 * pandas
 
@@ -103,6 +103,10 @@ microbenchmark.
 * `microbenchmark_custom_force` - Measure the time taken per step to use a constant custom force.
 * `microbenchmark_get_snapshot` - Measure the time taken to call State.get_snapshot.
 * `microbenchmark_set_snapshot` - Measure the time taken to call State.set_snapshot.
+* `write_gsd` - Measure how many GSD frames (containing particle positions) can be written per
+  second.
+* `write_gsd_log` - Measure how many GSD frames (containing 1 logged value) can be written per
+  second.
 
 ## Change log
 

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -23,6 +23,8 @@ from .microbenchmark_custom_updater import MicrobenchmarkCustomUpdater
 from .microbenchmark_custom_force import MicrobenchmarkCustomForce
 from .microbenchmark_get_snapshot import MicrobenchmarkGetSnapshot
 from .microbenchmark_set_snapshot import MicrobenchmarkSetSnapshot
+from .write_gsd import GSD
+from .write_gsd_log import GSDLog
 
 benchmark_classes = [
     HPMCSphere,
@@ -37,6 +39,8 @@ benchmark_classes = [
     MicrobenchmarkCustomForce,
     MicrobenchmarkGetSnapshot,
     MicrobenchmarkSetSnapshot,
+    GSD,
+    GSDLog,
 ]
 
 parser = common.Benchmark.make_argument_parser()

--- a/hoomd_benchmarks/write_gsd.py
+++ b/hoomd_benchmarks/write_gsd.py
@@ -53,11 +53,11 @@ class GSD(common.Benchmark):
     def make_write_gsd(self):
         """Make the GSD writer object for benchmarking."""
         writer = hoomd.write.GSD(trigger=hoomd.trigger.Periodic(1),
-                               filename='write_gsd.gsd',
-                               mode='wb')
+                                 filename='write_gsd.gsd',
+                                 mode='wb')
 
         try:
-            writer.dynamic=['particles/position']
+            writer.dynamic = ['particles/position']
         except hoomd.error.TypeConversionError:
             pass
 

--- a/hoomd_benchmarks/write_gsd.py
+++ b/hoomd_benchmarks/write_gsd.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Benchmark GSD writes."""
+
+import hoomd
+import time
+from . import common
+from .configuration.hard_sphere import make_hard_sphere_configuration
+
+DEFAULT_BANDWIDTH = 'false'
+DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 64 * 1024 * 1024
+
+
+class GSD(common.Benchmark):
+    """Base class GSD benchmark.
+
+    Args:
+        kwargs: Keyword arguments accepted by ``Benchmark.__init__``
+
+    Derived classes should set override `make_write_gsd` to implement
+    different options.
+
+    See Also:
+        `common.Benchmark`
+    """
+    SUITE_STEP_SCALE = 0.01
+
+    def __init__(self,
+                 bandwidth=DEFAULT_BANDWIDTH,
+                 maximum_write_buffer_size=DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE,
+                 **kwargs):
+        self.bandwidth = bandwidth
+        self.maximum_write_buffer_size = maximum_write_buffer_size
+
+        if bandwidth:
+            self.units = 'MiB/s'
+
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def make_argument_parser():
+        """Make an ArgumentParser instance for benchmark options."""
+        parser = common.Benchmark.make_argument_parser()
+        parser.add_argument('--bandwidth',
+                            action='store_true',
+                            help='Report performance in bandwidth.')
+        parser.add_argument('--maximum_write_buffer_size',
+                            type=int,
+                            default=DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE,
+                            help='Maximum size of the write buffer (in bytes).')
+        return parser
+
+    def make_write_gsd(self):
+        """Make the GSD writer object for benchmarking."""
+        writer = hoomd.write.GSD(trigger=hoomd.trigger.Periodic(1),
+                               filename='write_gsd.gsd',
+                               mode='wb')
+
+        try:
+            writer.dynamic=['particles/position']
+        except hoomd.error.TypeConversionError:
+            pass
+
+        return writer
+
+    def make_simulation(self):
+        """Make the Simulation object."""
+        path = make_hard_sphere_configuration(N=self.N,
+                                              rho=self.rho,
+                                              dimensions=self.dimensions,
+                                              device=self.device,
+                                              verbose=self.verbose)
+
+        sim = hoomd.Simulation(device=self.device)
+        sim.create_state_from_gsd(filename=str(path))
+
+        self.writer = self.make_write_gsd()
+        self.writer.maximum_write_buffer_size = self.maximum_write_buffer_size
+        sim.operations.writers.append(self.writer)
+
+        return sim
+
+    def run(self, steps):
+        """Run the benchmark for the given number of steps."""
+        start_time = time.time()
+
+        self.sim.run(steps)
+        if hasattr(self.writer, 'flush'):
+            self.writer.flush()
+        end_time = time.time()
+
+        self.tps = steps / (end_time - start_time)
+
+    def get_performance(self):
+        """Get the performance of the benchmark during the last ``run``."""
+        if self.bandwidth:
+            return self.N * 4 * 3 / 1024**2 * self.tps
+        else:
+            return self.tps
+
+
+if __name__ == '__main__':
+    GSD.main()

--- a/hoomd_benchmarks/write_gsd.py
+++ b/hoomd_benchmarks/write_gsd.py
@@ -32,10 +32,10 @@ class GSD(common.Benchmark):
         self.bandwidth = bandwidth
         self.maximum_write_buffer_size = maximum_write_buffer_size
 
+        super().__init__(**kwargs)
+
         if bandwidth:
             self.units = 'MiB/s'
-
-        super().__init__(**kwargs)
 
     @staticmethod
     def make_argument_parser():

--- a/hoomd_benchmarks/write_gsd.py
+++ b/hoomd_benchmarks/write_gsd.py
@@ -24,7 +24,6 @@ class GSD(common.Benchmark):
     See Also:
         `common.Benchmark`
     """
-    SUITE_STEP_SCALE = 0.01
 
     def __init__(self,
                  bandwidth=DEFAULT_BANDWIDTH,

--- a/hoomd_benchmarks/write_gsd.py
+++ b/hoomd_benchmarks/write_gsd.py
@@ -37,6 +37,8 @@ class GSD(common.Benchmark):
         if bandwidth:
             self.units = 'MiB/s'
 
+        self.bytes_per_step = self.N * 4 * 3 / 1024**2
+
     @staticmethod
     def make_argument_parser():
         """Make an ArgumentParser instance for benchmark options."""
@@ -94,7 +96,7 @@ class GSD(common.Benchmark):
     def get_performance(self):
         """Get the performance of the benchmark during the last ``run``."""
         if self.bandwidth:
-            return self.N * 4 * 3 / 1024**2 * self.tps
+            return self.bytes_per_step * self.tps
         else:
             return self.tps
 

--- a/hoomd_benchmarks/write_gsd.py
+++ b/hoomd_benchmarks/write_gsd.py
@@ -8,7 +8,7 @@ import time
 from . import common
 from .configuration.hard_sphere import make_hard_sphere_configuration
 
-DEFAULT_BANDWIDTH = 'false'
+DEFAULT_BANDWIDTH = False
 DEFAULT_MAXIMUM_WRITE_BUFFER_SIZE = 64 * 1024 * 1024
 
 

--- a/hoomd_benchmarks/write_gsd_log.py
+++ b/hoomd_benchmarks/write_gsd_log.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Benchmark GSD writes."""
+
+import hoomd
+from . import write_gsd
+
+
+class GSDLog(write_gsd.GSD):
+    """Log-only GSD benchmark.
+
+    Args:
+        kwargs: Keyword arguments accepted by ``GSD.__init__``
+
+    See Also:
+        `write_gsd.GSD`
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def make_write_gsd(self):
+        """Make the GSD writer object for benchmarking."""
+        logger = hoomd.logging.Logger(categories=['scalar', 'string'])
+        logger[('value')] = (lambda: 42, 'scalar')
+
+        return hoomd.write.GSD(trigger=hoomd.trigger.Periodic(1),
+                               filename='write_gsd_log.gsd',
+                               mode='wb',
+                               filter=hoomd.filter.Null(),
+                               logger=logger)
+
+
+if __name__ == '__main__':
+    GSDLog.main()

--- a/hoomd_benchmarks/write_gsd_log.py
+++ b/hoomd_benchmarks/write_gsd_log.py
@@ -20,6 +20,8 @@ class GSDLog(write_gsd.GSD):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        self.bytes_per_step = 28 / 1024**2
+
     def make_write_gsd(self):
         """Make the GSD writer object for benchmarking."""
         logger = hoomd.logging.Logger(categories=['scalar', 'string'])

--- a/hoomd_benchmarks/write_gsd_log.py
+++ b/hoomd_benchmarks/write_gsd_log.py
@@ -20,6 +20,7 @@ class GSDLog(write_gsd.GSD):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        # 24 bytes of index + 4 bytes of logged data
         self.bytes_per_step = 28 / 1024**2
 
     def make_write_gsd(self):


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add the `write_gsd` and `write_gsd_log` benchmarks.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Ensure that GSD file write performance remains high. 

## How has this been tested?

I used these benchmarks to test:
* https://github.com/glotzerlab/hoomd-blue/pull/1538
* https://github.com/glotzerlab/gsd/pull/237
* https://github.com/glotzerlab/hoomd-blue/pull/1541

Local tests with the single benchmark and suite entry points work as expected.
<!--- Please describe in detail how you tested your changes. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
