### PR TITLE
Add progress report to hard sphere compression.

### DIFF
--- a/hoomd_benchmarks/configuration/hard_sphere.py
+++ b/hoomd_benchmarks/configuration/hard_sphere.py
@@ -134,7 +134,7 @@ def make_hard_sphere_configuration(N,
             progress = (math.fabs(initial_box.volume - box.volume)
                         / math.fabs(initial_box.volume - final_box.volume))
             print(f'.. step {sim.timestep} at {tps:0.4g} TPS: '
-                  f'progress {progress:0.3g}')
+                  f'progress {progress*100:0.4g}%')
 
     if not compress.complete:
         raise RuntimeError('Compression failed to complete')

--- a/hoomd_benchmarks/configuration/hard_sphere.py
+++ b/hoomd_benchmarks/configuration/hard_sphere.py
@@ -129,8 +129,12 @@ def make_hard_sphere_configuration(N,
     while not compress.complete and sim.timestep < 1e5:
         sim.run(100)
         tps = sim.tps
+        box = sim.state.box
         if print_messages:
-            print(f'.. step {sim.timestep} at {tps:0.4g} TPS')
+            progress = (math.fabs(initial_box.volume - box.volume)
+                        / math.fabs(initial_box.volume - final_box.volume))
+            print(f'.. step {sim.timestep} at {tps:0.4g} TPS: '
+                  f'progress {progress:0.3g}')
 
     if not compress.complete:
         raise RuntimeError('Compression failed to complete')


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add progress report to hard sphere compression.
## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Let users know how quickly the compression step is progressing.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested locally:

```$ mpirun -n 24 python -m hoomd_benchmarks.md_pair_wca --device CPU -N 2000000 --warmup_steps=10 --benchmark_steps=10 -v                     
Generating initial_configuration_cache/hard_sphere_2000000_1.0_3.gsd
notice(2): Using domain decomposition: n_x = 2 n_y = 3 n_z = 4.
.. randomizing positions
.. step 100 at 1.842 TPS
.. step 200 at 1.793 TPS
.. step 300 at 1.811 TPS
.. step 400 at 1.789 TPS
.. step 500 at 1.808 TPS
.. step 600 at 1.787 TPS
.. step 700 at 1.814 TPS
.. step 800 at 1.794 TPS
.. step 900 at 1.808 TPS
.. step 1000 at 1.778 TPS
.. compressing
.. step 1100 at 1.763 TPS: progress 0.0859
.. step 1200 at 1.72 TPS: progress 0.187
.. step 1300 at 1.744 TPS: progress 0.287
.. step 1400 at 1.694 TPS: progress 0.343
.. step 1500 at 1.732 TPS: progress 0.409
.. step 1600 at 1.69 TPS: progress 0.482
.. step 1700 at 1.733 TPS: progress 0.525
.. step 1800 at 1.69 TPS: progress 0.574
.. step 1900 at 1.73 TPS: progress 0.622
.. step 2000 at 1.688 TPS: progress 0.651
.. step 2100 at 1.729 TPS: progress 0.704
.. step 2200 at 1.7 TPS: progress 0.729
.. step 2300 at 1.751 TPS: progress 0.744
.. step 2400 at 1.715 TPS: progress 0.759
.. step 2500 at 1.769 TPS: progress 0.791
.. step 2600 at 1.736 TPS: progress 0.812
.. step 2700 at 1.79 TPS: progress 0.836
.. step 2800 at 1.765 TPS: progress 0.853
.. step 2900 at 1.808 TPS: progress 0.856
.. step 3000 at 1.801 TPS: progress 0.879
.. step 3100 at 1.832 TPS: progress 0.896
.. step 3200 at 1.827 TPS: progress 0.898
.. step 3300 at 1.857 TPS: progress 0.913
.. step 3400 at 1.863 TPS: progress 0.924
.. step 3500 at 1.874 TPS: progress 0.93
.. step 3600 at 1.845 TPS: progress 0.938
.. step 3700 at 1.868 TPS: progress 0.94
.. step 3800 at 1.843 TPS: progress 0.957
.. step 3900 at 1.853 TPS: progress 0.964
.. step 4000 at 1.814 TPS: progress 0.965
.. step 4100 at 1.856 TPS: progress 0.968
.. step 4200 at 1.833 TPS: progress 0.979
.. step 4300 at 1.842 TPS: progress 0.981
.. step 4400 at 1.82 TPS: progress 0.989
.. step 4500 at 1.843 TPS: progress 0.994
.. step 4600 at 1.817 TPS: progress 0.995
.. step 4700 at 1.842 TPS: progress 1
.. step 4800 at 1.826 TPS: progress 1
.. done
notice(2): Using domain decomposition: n_x = 2 n_y = 3 n_z = 4.
Running MDPairWCA benchmark
.. warming up for 10 steps
.. running for 10 steps 1 time(s)
.. 8.943375909764914 time steps per second
8.943375909764914    
```

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
