### PR TITLE
Add microbenchmark for accessing per-particle force arrays

### DIFF
--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -5,9 +5,10 @@
 
 import copy
 import fnmatch
+import os
+
 import hoomd
 import numpy
-import os
 import pandas
 
 from . import common
@@ -21,9 +22,9 @@ from .microbenchmark_custom_force import MicrobenchmarkCustomForce
 from .microbenchmark_custom_trigger import MicrobenchmarkCustomTrigger
 from .microbenchmark_custom_updater import MicrobenchmarkCustomUpdater
 from .microbenchmark_empty_simulation import MicrobenchmarkEmptySimulation
+from .microbenchmark_force_array_access import MicrobenchmarkForceArrayAccess
 from .microbenchmark_get_snapshot import MicrobenchmarkGetSnapshot
 from .microbenchmark_set_snapshot import MicrobenchmarkSetSnapshot
-from .microbenchmark_force_array_access import MicrobenchmarkForceArrayAccess
 from .write_gsd import GSD
 from .write_gsd_log import GSDLog
 from .write_hdf5_log import HDF5Log

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -24,6 +24,7 @@ from .microbenchmark_custom_updater import MicrobenchmarkCustomUpdater
 from .microbenchmark_empty_simulation import MicrobenchmarkEmptySimulation
 from .microbenchmark_get_snapshot import MicrobenchmarkGetSnapshot
 from .microbenchmark_set_snapshot import MicrobenchmarkSetSnapshot
+from .microbenchmark_force_array_access import MicrobenchmarkForceArrayAccess
 from .write_gsd import GSD
 from .write_gsd_log import GSDLog
 from .write_hdf5_log import HDF5Log
@@ -41,6 +42,7 @@ benchmark_classes = [
     MicrobenchmarkCustomForce,
     MicrobenchmarkGetSnapshot,
     MicrobenchmarkSetSnapshot,
+    MicrobenchmarkForceArrayAccess,
     GSD,
     GSDLog,
     HDF5Log,

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -5,10 +5,9 @@
 
 import copy
 import fnmatch
-import os
-
 import hoomd
 import numpy
+import os
 import pandas
 
 from . import common

--- a/hoomd_benchmarks/microbenchmark_force_array_access.py
+++ b/hoomd_benchmarks/microbenchmark_force_array_access.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Force array access benchmark."""
+
+import warnings
+
+import hoomd
+import numpy as np
+
+from . import common
+from .configuration.hard_sphere import make_hard_sphere_configuration
+from .microbenchmark_custom_force import ConstantForce
+
+
+class AccessForceAction(hoomd.custom.Action):
+    def __init__(self, force=None):
+        self._force = force
+
+    def act(self, timestep):
+        """Access the forces arrays but do nothing with them."""
+        if self._force is None:
+            return
+        forces = self._force.forces
+        energies = self._force.energies
+        torques = self._force.torques
+        virials = self._force.virials
+
+class MicrobenchmarkForceArrayAccess(common.ComparativeBenchmark):
+    """Measure the overhead of accessing the force arrays.
+
+    Add an AccessForceAction object to both simulations, but only populate one
+    of them with a Force object. Then the only difference in the performance
+    between the two simulations will the caused by accessing the arrays 
+    associated with the Force object.
+    """
+
+    def make_simulations(self):
+        """Make the simulation objects."""
+        path = make_hard_sphere_configuration(
+            N=self.N,
+            rho=self.rho,
+            dimensions=self.dimensions,
+            device=self.device,
+            verbose=self.verbose,
+        )
+
+        dt = 0.0
+        sim0 = hoomd.Simulation(device=self.device, seed=100)
+        sim0.create_state_from_gsd(filename=str(path))
+        sim0.operations.updaters.clear()
+        sim0.operations.computes.clear()
+        sim0.operations.writers.clear()
+        sim0.operations.tuners.clear()
+        sim0.operations.integrator = hoomd.md.Integrator(
+            dt=dt,
+            methods=[hoomd.md.methods.ConstantVolume(filter=hoomd.filter.All())],
+        )
+        constant_custom_force_sim0 = ConstantForce(5, sim0.device)
+        sim0.operations.integrator.forces.append(constant_custom_force_sim0)
+        # don't add force to writer in sim0
+        sim0.operations.add(hoomd.write.CustomWriter(1, AccessForceAction()))
+
+        sim1 = hoomd.Simulation(device=self.device, seed=100)
+        sim1.create_state_from_gsd(filename=str(path))
+        sim1.operations.updaters.clear()
+        sim1.operations.computes.clear()
+        sim1.operations.writers.clear()
+        sim1.operations.tuners.clear()
+        sim1.operations.integrator = hoomd.md.Integrator(
+            dt=dt,
+            methods=[hoomd.md.methods.ConstantVolume(filter=hoomd.filter.All())],
+        )
+        constant_custom_force_sim1 = ConstantForce(5, sim1.device)
+        sim1.operations.integrator.forces.append(constant_custom_force_sim1)
+        # do add force to writer in sim1
+        sim1.operations.add(
+            hoomd.write.CustomWriter(1, AccessForceAction(constant_custom_force_sim1)))
+
+        return sim0, sim1
+
+
+if __name__ == '__main__':
+    MicrobenchmarkForceArrayAccess.main()

--- a/hoomd_benchmarks/microbenchmark_force_array_access.py
+++ b/hoomd_benchmarks/microbenchmark_force_array_access.py
@@ -3,10 +3,7 @@
 
 """Force array access benchmark."""
 
-import warnings
-
 import hoomd
-import numpy as np
 
 from . import common
 from .configuration.hard_sphere import make_hard_sphere_configuration
@@ -14,6 +11,8 @@ from .microbenchmark_custom_force import ConstantForce
 
 
 class AccessForceAction(hoomd.custom.Action):
+    """An action to access the per-particle force arrays."""
+
     def __init__(self, force=None):
         self._force = force
 
@@ -21,18 +20,19 @@ class AccessForceAction(hoomd.custom.Action):
         """Access the forces arrays but do nothing with them."""
         if self._force is None:
             return
-        forces = self._force.forces
-        energies = self._force.energies
-        torques = self._force.torques
-        virials = self._force.virials
+        forces = self._force.forces  # noqa: F841
+        energies = self._force.energies  # noqa: F841
+        torques = self._force.torques  # noqa: F841
+        virials = self._force.virials  # noqa: F841
+
 
 class MicrobenchmarkForceArrayAccess(common.ComparativeBenchmark):
     """Measure the overhead of accessing the force arrays.
 
     Add an AccessForceAction object to both simulations, but only populate one
     of them with a Force object. Then the only difference in the performance
-    between the two simulations will the caused by accessing the arrays 
-    associated with the Force object.
+    between the two simulations will caused by accessing the arrays associated
+    with the Force object.
     """
 
     def make_simulations(self):
@@ -75,7 +75,8 @@ class MicrobenchmarkForceArrayAccess(common.ComparativeBenchmark):
         sim1.operations.integrator.forces.append(constant_custom_force_sim1)
         # do add force to writer in sim1
         sim1.operations.add(
-            hoomd.write.CustomWriter(1, AccessForceAction(constant_custom_force_sim1)))
+            hoomd.write.CustomWriter(1, AccessForceAction(constant_custom_force_sim1))
+        )
 
         return sim0, sim1
 


### PR DESCRIPTION
## Description

Adds a comparative benchmark to benchmark the overhead of accessing the per-particle force arrays of a Force object.

## Motivation and context

Useful for testing performance improvements introduced in https://github.com/glotzerlab/hoomd-blue/pull/1654.

## How has this been tested?

It runs and I get sensible results.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
