### PR TITLE
HPMC pair lj benchmark.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 *.gsd
 *.csv
 *.h5
+perf.data*
+.gdb_history

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -110,7 +110,7 @@ if args.output is not None and benchmark_args['device'].communicator.rank == 0:
 
     if os.path.isfile(args.output):
         df_old = pandas.read_csv(args.output, index_col=0)
-        df = df_old.join(df)
+        df = df_old.join(df, how='outer')
 
     with open(args.output, 'w') as f:
         f.write(df.to_csv())

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -13,6 +13,8 @@ import pandas
 
 from . import common
 from .hpmc_sphere import HPMCSphere
+from .hpmc_octahedron import HPMCOctahedron
+from .hpmc_pair_lj import HPMCPairLJ
 from .md_pair_lj import MDPairLJ
 from .md_pair_opp import MDPairOPP
 from .md_pair_table import MDPairTable
@@ -31,6 +33,8 @@ from .write_hdf5_log import HDF5Log
 
 benchmark_classes = [
     HPMCSphere,
+    HPMCOctahedron,
+    HPMCPairLJ,
     MDPairLJ,
     MDPairOPP,
     MDPairTable,
@@ -74,7 +78,9 @@ benchmark_args_ref = copy.deepcopy(vars(args))
 del benchmark_args_ref['benchmarks']
 del benchmark_args_ref['output']
 del benchmark_args_ref['name']
-benchmark_args_ref['device'] = common.make_hoomd_device(args)
+
+device = common.make_hoomd_device(args)
+benchmark_args_ref['device'] = device
 
 performance = {}
 
@@ -85,7 +91,7 @@ for benchmark_class in benchmark_classes:
     benchmark_args['benchmark_steps'] *= benchmark_class.SUITE_STEP_SCALE
 
     name = benchmark_class.__name__
-    if fnmatch.fnmatch(name, args.benchmarks):
+    if fnmatch.fnmatch(name, args.benchmarks) and benchmark_class.runs_on_device(device):
         benchmark = benchmark_class(**benchmark_args)
         performance[name] = benchmark.execute()
 

--- a/hoomd_benchmarks/__main__.py
+++ b/hoomd_benchmarks/__main__.py
@@ -12,9 +12,9 @@ import numpy
 import pandas
 
 from . import common
-from .hpmc_sphere import HPMCSphere
 from .hpmc_octahedron import HPMCOctahedron
 from .hpmc_pair_lj import HPMCPairLJ
+from .hpmc_sphere import HPMCSphere
 from .md_pair_lj import MDPairLJ
 from .md_pair_opp import MDPairOPP
 from .md_pair_table import MDPairTable
@@ -91,7 +91,9 @@ for benchmark_class in benchmark_classes:
     benchmark_args['benchmark_steps'] *= benchmark_class.SUITE_STEP_SCALE
 
     name = benchmark_class.__name__
-    if fnmatch.fnmatch(name, args.benchmarks) and benchmark_class.runs_on_device(device):
+    if fnmatch.fnmatch(name, args.benchmarks) and benchmark_class.runs_on_device(
+        device
+    ):
         benchmark = benchmark_class(**benchmark_args)
         performance[name] = benchmark.execute()
 

--- a/hoomd_benchmarks/common.py
+++ b/hoomd_benchmarks/common.py
@@ -205,6 +205,11 @@ class Benchmark:
         return parser
 
     @classmethod
+    def runs_on_device(cls, device):
+        """Returns True when the benchmark can be run on the given device."""
+        return True
+
+    @classmethod
     def main(cls):
         """Implement the command line entrypoint for benchmarks."""
         parser = cls.make_argument_parser()

--- a/hoomd_benchmarks/hpmc_base.py
+++ b/hoomd_benchmarks/hpmc_base.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Base class HPMC benchmark."""
+
+from . import common
+
+
+class HPMCBenchmark(common.Benchmark):
+    """Base class HPMC benchmark.
+
+    Computes performance in sweeps per second and prints out MC diagnostic information
+    in verbose mode.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.units = 'sweeps per second'
+
+    def get_performance(self):
+        """Get the performance in sweeps per second."""
+        return self.sim.operations.integrator.mps / self.sim.state.N_particles
+
+    def run(self, steps):
+        """Run the benchmark and report HPMC specific info in verbose mode."""
+        super().run(steps)
+
+        if self.verbose and steps > 0:
+            t = self.sim.operations.integrator.translate_moves
+            r = self.sim.operations.integrator.rotate_moves
+            self.device.notice(f'.. translate acceptance: {t[0] / sum(t)}')
+            if sum(r) > 0:
+                self.device.notice(f'.. rotate acceptance: {r[0] / sum(r)}')
+
+            overlap_checks = self.sim.operations.integrator.counters.overlap_checks
+            overlap_checks /= sum(t) + sum(r)
+            self.device.notice(f'.. overlap checks per trial move: {overlap_checks}')

--- a/hoomd_benchmarks/hpmc_octahedron.py
+++ b/hoomd_benchmarks/hpmc_octahedron.py
@@ -44,5 +44,6 @@ class HPMCOctahedron(hpmc_base.HPMCBenchmark):
 
         return sim
 
+
 if __name__ == '__main__':
     HPMCOctahedron.main()

--- a/hoomd_benchmarks/hpmc_octahedron.py
+++ b/hoomd_benchmarks/hpmc_octahedron.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Hard octahedron Monte Carlo benchmark."""
+
+import hoomd
+
+from . import hpmc_base
+from .configuration.hard_sphere import make_hard_sphere_configuration
+
+
+class HPMCOctahedron(hpmc_base.HPMCBenchmark):
+    """Hard particle Monte Carlo octahedron benchmark.
+
+    See Also:
+        `hpmc_base.HPMCBenchmark`
+    """
+
+    def make_simulation(self):
+        """Make the Simulation object."""
+        path = make_hard_sphere_configuration(
+            N=self.N,
+            rho=self.rho,
+            dimensions=self.dimensions,
+            device=self.device,
+            verbose=self.verbose,
+        )
+
+        mc = hoomd.hpmc.integrate.ConvexPolyhedron()
+        mc.shape['A'] = dict(
+            vertices=[
+                (-0.5, 0, 0),
+                (0.5, 0, 0),
+                (0, -0.5, 0),
+                (0, 0.5, 0),
+                (0, 0, -0.5),
+                (0, 0, 0.5),
+            ]
+        )
+
+        sim = hoomd.Simulation(device=self.device, seed=100)
+        sim.create_state_from_gsd(filename=str(path))
+        sim.operations.integrator = mc
+
+        return sim
+
+if __name__ == '__main__':
+    HPMCOctahedron.main()

--- a/hoomd_benchmarks/hpmc_pair.py
+++ b/hoomd_benchmarks/hpmc_pair.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Methods common to HPMC pair potential benchmarks."""
+
+import hoomd
+
+from . import common, hpmc_base
+from .configuration.hard_sphere import make_hard_sphere_configuration
+
+DEFAULT_MODE = 'compiled'
+
+
+class HPMCPair(hpmc_base.HPMCBenchmark):
+    """Base class HPMC pair potential benchmark.
+
+    Args:
+        mode (str): Set to 'compiled' to use a compiled pair potential. Set to
+          'code' to use CPPPotential.
+
+        kwargs: Keyword arguments accepted by ``Benchmark.__init__``
+
+    Derived classes should set the class level variables ``pair_class``,
+    ``pair_params``, ``r_cut``, and ``code``.
+
+    See Also:
+        `common.Benchmark`
+    """
+
+    def __init__(
+        self,
+        mode=DEFAULT_MODE,
+        **kwargs,
+    ):
+        self.mode = mode
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def make_argument_parser():
+        """Make an ArgumentParser instance for benchmark options."""
+        parser = common.Benchmark.make_argument_parser()
+        parser.add_argument('--mode', default=DEFAULT_MODE, help='Compute mode.')
+        return parser
+
+    def make_simulation(self):
+        """Make the Simulation object."""
+        path = make_hard_sphere_configuration(
+            N=self.N,
+            rho=self.rho,
+            dimensions=self.dimensions,
+            device=self.device,
+            verbose=self.verbose,
+        )
+
+        integrator = hoomd.hpmc.integrate.Sphere(default_d=0.18)
+        integrator.shape['A'] = dict(diameter=0)
+
+        sim = hoomd.Simulation(device=self.device)
+        sim.create_state_from_gsd(filename=str(path))
+
+        if self.mode == 'compiled':
+            pair = self.pair_class()
+            pair.params[('A', 'A')] = self.pair_params
+            integrator.pair_potentials = [pair]
+        elif self.mode == 'code':
+            patch = hoomd.hpmc.pair.user.CPPPotential(
+                code=self.code, r_cut=self.r_cut, param_array=[]
+            )
+            integrator.pair_potential = patch
+        else:
+            raise ValueError('Invalid mode: ', self.mode)
+
+        sim.operations.integrator = integrator
+
+        return sim

--- a/hoomd_benchmarks/hpmc_pair.py
+++ b/hoomd_benchmarks/hpmc_pair.py
@@ -55,7 +55,7 @@ class HPMCPair(hpmc_base.HPMCBenchmark):
         integrator = hoomd.hpmc.integrate.Sphere(default_d=0.18)
         integrator.shape['A'] = dict(diameter=0)
 
-        sim = hoomd.Simulation(device=self.device)
+        sim = hoomd.Simulation(device=self.device, seed=10)
         sim.create_state_from_gsd(filename=str(path))
 
         if self.mode == 'compiled':
@@ -73,3 +73,16 @@ class HPMCPair(hpmc_base.HPMCBenchmark):
         sim.operations.integrator = integrator
 
         return sim
+
+    @classmethod
+    def runs_on_device(cls, device):
+        """Returns True when the benchmark can be run on the given device."""
+        if isinstance(device, hoomd.device.GPU):
+            return False
+
+        if cls.pair_class is None:
+            # Skip this benchmark on HOOMD releases that lack the needed pair
+            # potential.
+            return False
+
+        return True

--- a/hoomd_benchmarks/hpmc_pair_lj.py
+++ b/hoomd_benchmarks/hpmc_pair_lj.py
@@ -21,7 +21,7 @@ class HPMCPairLJ(hpmc_pair.HPMCPair):
 
     code = """
             float rsq = dot(r_ij, r_ij);
-            float r_cut = {{ self.r_cut }};
+            float r_cut = {{ r_cut }};
             float r_cutsq = r_cut * r_cut;
 
             if (rsq >= r_cutsq)

--- a/hoomd_benchmarks/hpmc_pair_lj.py
+++ b/hoomd_benchmarks/hpmc_pair_lj.py
@@ -15,13 +15,13 @@ class HPMCPairLJ(hpmc_pair.HPMCPair):
         `hpmc_pair.HPMCPair`
     """
 
-    pair_class = getattr(hoomd.hpmc.pair, 'LennardJones', None)
-    pair_params = dict(epsilon=1, sigma=1, r_cut=2.5)
     r_cut = 2.5
+    pair_class = getattr(hoomd.hpmc.pair, 'LennardJones', None)
+    pair_params = dict(epsilon=1, sigma=1, r_cut=r_cut, mode='shift')
 
     code = """
             float rsq = dot(r_ij, r_ij);
-            float r_cut = 2.5;
+            float r_cut = {{ self.r_cut }};
             float r_cutsq = r_cut * r_cut;
 
             if (rsq >= r_cutsq)

--- a/hoomd_benchmarks/hpmc_pair_lj.py
+++ b/hoomd_benchmarks/hpmc_pair_lj.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2021-2023 The Regents of the University of Michigan
+# Part of HOOMD-blue, released under the BSD 3-Clause License.
+
+"""Lennard-Jones HPMC pair potential benchmark."""
+
+import hoomd
+
+from . import hpmc_pair
+
+
+class HPMCPairLJ(hpmc_pair.HPMCPair):
+    """HPMC Lennard-Jones pair potential benchmark.
+
+    See Also:
+        `hpmc_pair.HPMCPair`
+    """
+
+    pair_class = getattr(hoomd.hpmc.pair, 'LennardJones', None)
+    pair_params = dict(epsilon=1, sigma=1, r_cut=2.5)
+    r_cut = 2.5
+
+    code = """
+            float rsq = dot(r_ij, r_ij);
+            float r_cut = 2.5;
+            float r_cutsq = r_cut * r_cut;
+
+            if (rsq >= r_cutsq)
+                return 0.0f;
+
+            float sigma = 1.0;
+            float sigsq = sigma * sigma;
+            float rsqinv = sigsq / rsq;
+            float r6inv = rsqinv * rsqinv * rsqinv;
+            float r12inv = r6inv * r6inv;
+            return 4 * 1.0 * (r12inv - r6inv);
+            """
+
+
+if __name__ == '__main__':
+    HPMCPairLJ.main()

--- a/hoomd_benchmarks/hpmc_sphere.py
+++ b/hoomd_benchmarks/hpmc_sphere.py
@@ -5,15 +5,15 @@
 
 import hoomd
 
-from . import common
+from . import hpmc_base
 from .configuration.hard_sphere import make_hard_sphere_configuration
 
 
-class HPMCSphere(common.Benchmark):
+class HPMCSphere(hpmc_base.HPMCBenchmark):
     """Hard particle Monte Carlo sphere benchmark.
 
     See Also:
-        `common.Benchmark`
+        `hpmc_base.HPMCBenchmark`
     """
 
     def make_simulation(self):

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -106,6 +106,14 @@ class MicrobenchmarkCustomForce(common.ComparativeBenchmark):
 
         return sim0, sim1
 
+    @classmethod
+    def runs_on_device(cls, device):
+        """Returns True when the benchmark can be run on the given device."""
+        if isinstance(device, hoomd.device.GPU) and not CUPY_IMPORTED:
+            # cupy is required to run this device on the GPU
+            return False
+
+        return True
 
 if __name__ == '__main__':
     MicrobenchmarkCustomForce.main()

--- a/hoomd_benchmarks/microbenchmark_custom_force.py
+++ b/hoomd_benchmarks/microbenchmark_custom_force.py
@@ -115,5 +115,6 @@ class MicrobenchmarkCustomForce(common.ComparativeBenchmark):
 
         return True
 
+
 if __name__ == '__main__':
     MicrobenchmarkCustomForce.main()


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add HPMC pair LJ benchmark and octahedron benchmark. Also add a new base class HPMC benchmark that reports acceptance ratios and overlaps per particle to aid in testing.

The `HPMCPair` benchmarks default to running on the compiled potential. If the compiled potential is not available, the benchmark suite will skip the benchmark.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
* Evaluate performance of CPPPotential compared to potentials provided at compile time.
* Evaluate the performance of hard polyhedra simulations.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I have run these benchmark locally.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**HOOMD-blue Contributor Agreement**](https://github.com/glotzerlab/hoomd-blue/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`CONTRIBUTORS.md`) in the pull request source branch.
